### PR TITLE
Fix/get body

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,19 +9,19 @@ GEM
   specs:
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    base64 (0.2.0)
-    bigdecimal (3.1.9)
-    bigdecimal (3.1.9-java)
+    base64 (0.3.0)
+    bigdecimal (3.2.3)
+    bigdecimal (3.2.3-java)
     crack (1.0.0)
       bigdecimal
       rexml
-    hashdiff (1.1.2)
+    hashdiff (1.2.1)
     httpclient (2.9.0)
       mutex_m
     minitest (5.25.5)
     mutex_m (0.3.0)
-    public_suffix (6.0.1)
-    rake (13.2.1)
+    public_suffix (6.0.2)
+    rake (13.3.0)
     rexml (3.4.4)
     webmock (3.25.1)
       addressable (>= 2.8.0)

--- a/lib/tinify/source.rb
+++ b/lib/tinify/source.rb
@@ -43,7 +43,12 @@ module Tinify
     end
 
     def result
-      response = Tinify.client.request(:get, @url, @commands)
+      response = if @commands&.empty?
+                    Tinify.client.request(:get, @url)
+                  else
+                    Tinify.client.request(:post, @url, @commands)
+                  end
+
       Result.new(response.headers, response.body).freeze
     end
 


### PR DESCRIPTION
Change `Tinify::Source` result instance method, to use a `:post` when a body is provided. Otherwise use a `:get`.